### PR TITLE
both the 'applicationId' and 'remoteApplicationId' properties populat…

### DIFF
--- a/remote-pay-cloud-nodejs-example/lib/ExampleCLI.js
+++ b/remote-pay-cloud-nodejs-example/lib/ExampleCLI.js
@@ -72,7 +72,7 @@ var exampleCLI = (function (module) {
             // Default to network configuration.
             let connectionConfiguration = {
                 "endpoint": endpoint,
-                "applicationId": answers.applicationId,
+                "remoteApplicationId": answers.remoteApplicationId,
                 "posName": "Clover Remote Pay Cloud Tutorial",
                 "serialNumber": "Register_1",
                 "authToken": null,

--- a/remote-pay-cloud-nodejs-example/lib/support/ExampleWebSocketDeviceConnectionConfiguration.js
+++ b/remote-pay-cloud-nodejs-example/lib/support/ExampleWebSocketDeviceConnectionConfiguration.js
@@ -15,7 +15,7 @@
         if (useCloud) {
             // Cloud Configuration.
             deviceConfiguration = new clover.WebSocketCloudCloverDeviceConfiguration(
-                connectionConfiguration.applicationId,
+                connectionConfiguration.remoteApplicationId,
                 connectionConfiguration.webSocketFactoryFunction,
                 connectionConfiguration.imageUtil,
                 connectionConfiguration.cloverServer,
@@ -29,7 +29,7 @@
             // Network Configuration.
             deviceConfiguration = new clover.WebSocketPairedCloverDeviceConfiguration(
                 connectionConfiguration.endpoint,
-                connectionConfiguration.applicationId,
+                connectionConfiguration.remoteApplicationId,
                 connectionConfiguration.posName,
                 connectionConfiguration.serialNumber,
                 connectionConfiguration.authToken,

--- a/remote-pay-cloud-nodejs-example/lib/support/Prompts.js
+++ b/remote-pay-cloud-nodejs-example/lib/support/Prompts.js
@@ -58,7 +58,7 @@
     prompts.configuration = [
         {
             type: "input",
-            name: "applicationId",
+            name: "remoteApplicationId",
             message: "Enter your Remote Application Id:",
             default: "com.mybus.myapp"
         },


### PR DESCRIPTION
…e the payment_extra.value.developerAppId column in our db. the other SDKs use 'remoteApplicationId' for config, so this repo should be consistent