### PR TITLE
add missing configuration property to `react-pay-cloud-pos-react`

### DIFF
--- a/remote-pay-cloud-pos-react/src/config.js
+++ b/remote-pay-cloud-pos-react/src/config.js
@@ -3,4 +3,5 @@ export const myConfig = {
     devicesDomain: 'https://apisandbox.dev.clover.com/v3/merchants/',
     oAuthDomain: 'https://sandbox.dev.clover.com',
     uriText: 'wss://10.249.255.103:12345/remote_pay',
+    cloverServer: 'https://apisandbox.dev.clover.com',
 };


### PR DESCRIPTION
`cloverServer` is required in config.js for React example to work